### PR TITLE
if cancel button text is null, then the cancel button should not render.

### DIFF
--- a/datepicker.js
+++ b/datepicker.js
@@ -363,7 +363,7 @@ class DatePicker extends Component {
               <View style={dateInputStyle}>
                 {this.getTitleElement()}
               </View>
-            :
+              :
               <View/>
           }
           {this._renderIcon()}
@@ -372,7 +372,9 @@ class DatePicker extends Component {
             animationType="none"
             visible={this.state.modalVisible}
             supportedOrientations={SUPPORTED_ORIENTATIONS}
-            onRequestClose={() => {this.setModalVisible(false);}}
+            onRequestClose={() => {
+              this.setModalVisible(false);
+            }}
           >
             <View
               style={{flex: 1}}
@@ -403,19 +405,22 @@ class DatePicker extends Component {
                         locale={locale}
                       />
                     </View>
-                    <TouchableComponent
-                      underlayColor={'transparent'}
-                      onPress={this.onPressCancel}
-                      style={[Style.btnText, Style.btnCancel, customStyles.btnCancel]}
-                      testID={cancelBtnTestID}
-                    >
-                      <Text
-                        allowFontScaling={allowFontScaling}
-                        style={[Style.btnTextText, Style.btnTextCancel, customStyles.btnTextCancel]}
+                    {cancelBtnText ?
+                      <TouchableComponent
+                        underlayColor={'transparent'}
+                        onPress={this.onPressCancel}
+                        style={[Style.btnText, Style.btnCancel, customStyles.btnCancel]}
+                        testID={cancelBtnTestID}
                       >
-                        {cancelBtnText}
-                      </Text>
-                    </TouchableComponent>
+                        <Text
+                          allowFontScaling={allowFontScaling}
+                          style={[Style.btnTextText, Style.btnTextCancel, customStyles.btnTextCancel]}
+                        >
+                          {cancelBtnText}
+                        </Text>
+                      </TouchableComponent>
+                      : null
+                    }
                     <TouchableComponent
                       underlayColor={'transparent'}
                       onPress={this.onPressConfirm}


### PR DESCRIPTION
This PR allows for users to pass `null` to the `cancelBtnText` in order to stop the cancel button from displaying. Currently, if you pass `null` or `""`, then nothing displays, but the left part of the bar remains clickable. 

Editing the local version of this app in my node_modules with these changes gives correct results:
![in_our_app](https://user-images.githubusercontent.com/1351120/61396798-ca272780-a8c8-11e9-8a06-46eb2ab0465b.gif)
